### PR TITLE
Allows sending no additional headers when no auth info is provided.

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -630,15 +630,12 @@ export class DockerDatasource extends Datasource {
     let url: string | null =
       `${registryHost}/${dockerRepository}/tags/list?n=${limit}`;
     url = ensurePathPrefix(url, '/v2');
-    const headers = await getAuthHeaders(
-      this.http,
-      registryHost,
-      dockerRepository,
-      url,
-    );
-    if (!headers) {
-      logger.debug('Failed to get authHeaders for getTags lookup');
-      return null;
+    const headers =
+      (await getAuthHeaders(this.http, registryHost, dockerRepository, url)) ||
+      {}; // uses empty headers if no authentication headers were provided by the registry
+
+    if (Object.keys(headers).length === 0) {
+      logger.debug('No authentication headers were found for getTags lookup');
     }
     let page = 0;
     const pages = process.env.RENOVATE_X_DOCKER_MAX_PAGES

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -637,6 +637,10 @@ export class DockerDatasource extends Datasource {
       url,
     )) || { 'Content-Type': 'application/json' }; // if empty headers are provided, error will not be caught
 
+    if (headers['Content-Type'] === 'application/json') {
+      logger.debug('No authentication headers found, using default headers');
+    }
+
     let page = 0;
     const pages = process.env.RENOVATE_X_DOCKER_MAX_PAGES
       ? parseInt(process.env.RENOVATE_X_DOCKER_MAX_PAGES, 10)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
